### PR TITLE
Add draft tournaments and events

### DIFF
--- a/src/app/dashboard/eventos/edit/form-evento.tsx
+++ b/src/app/dashboard/eventos/edit/form-evento.tsx
@@ -27,6 +27,7 @@ import Link from "next/link";
 import { useState } from "react";
 import { RefreshCcw, Search } from "lucide-react";
 import { useRouter } from "next/navigation";
+import { Switch } from "@/components/ui/switch";
 
 export default function FormEvento({
   evento,
@@ -45,6 +46,7 @@ export default function FormEvento({
   const [tourId, setTourId] = useState(evento ? evento.tourId : null);
   const [from, setFrom] = useState(evento ? evento.from : "");
   const [to, setTo] = useState(evento ? evento.to : "");
+  const [draft, setDraft] = useState(evento ? evento.draft : null);
   const [error, setError] = useState(false);
   const { toast } = useToast();
   const router = useRouter();
@@ -77,6 +79,7 @@ export default function FormEvento({
           tourId,
           from: date_from,
           to: date_to,
+          draft,
         })
         .then(() => {
           setLoading(false);
@@ -93,6 +96,7 @@ export default function FormEvento({
           tourId,
           from: date_from,
           to: date_to,
+          draft,
         })
         .eq("id", evento.id)
         .then(() => {
@@ -219,6 +223,10 @@ export default function FormEvento({
                 />
               </PopoverContent>
             </Popover>
+          </div>
+          <div className="flex items-center space-x-4">
+            <Label htmlFor="draft">Draft</Label>
+            <Switch checked={draft} onCheckedChange={() => setDraft(!draft)} />
           </div>
         </div>
         <div className="flex justify-end gap-4">

--- a/src/app/dashboard/events-columns.tsx
+++ b/src/app/dashboard/events-columns.tsx
@@ -30,7 +30,7 @@ export type Event = {
   draft: boolean;
 };
 
-export const columns: ColumnDef<Event>[] = [
+export const eventsColumns: ColumnDef<Event>[] = [
   {
     accessorKey: "id",
     header: ({ column }) => (
@@ -76,7 +76,7 @@ export const columns: ColumnDef<Event>[] = [
     ),
   },
   {
-    accessorKey: "dradft",
+    accessorKey: "draft",
     header: ({ column }) => (
       <DataTableColumnHeader column={column} title="Draft" />
     ),

--- a/src/app/dashboard/events-data-table.tsx
+++ b/src/app/dashboard/events-data-table.tsx
@@ -1,0 +1,129 @@
+"use client";
+import * as React from "react";
+
+import {
+  ColumnDef,
+  SortingState,
+  ColumnFiltersState,
+  flexRender,
+  getCoreRowModel,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { DataTablePagination } from "@/components/datatables/pagination";
+import { Input } from "@/components/ui/input";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+interface DataTableProps<TData, TValue> {
+  columns: ColumnDef<TData, TValue>[];
+  data: TData[];
+}
+
+export function EventsDataTable<TData, TValue>({
+  columns,
+  data,
+}: DataTableProps<TData, TValue>) {
+  const [sorting, setSorting] = React.useState<SortingState>([]);
+  const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>(
+    []
+  );
+
+  const table = useReactTable({
+    data,
+    columns,
+    getPaginationRowModel: getPaginationRowModel(),
+    getCoreRowModel: getCoreRowModel(),
+    onSortingChange: setSorting,
+    getSortedRowModel: getSortedRowModel(),
+    onColumnFiltersChange: setColumnFilters,
+    getFilteredRowModel: getFilteredRowModel(),
+
+    state: {
+      sorting,
+      columnFilters,
+    },
+  });
+
+  return (
+    <>
+      <div className="flex items-center justify-between py-4 gap-2">
+        <Input
+          placeholder="Buscar Evento..."
+          value={(table.getColumn("name")?.getFilterValue() as string) ?? ""}
+          onChange={(event) => {
+            table.getColumn("name")?.setFilterValue(event.target.value);
+          }}
+          className="max-w-sm"
+        />
+        <Link href="/admin/eventos/edit">
+          <Button>Nuevo Evento</Button>
+        </Link>
+      </div>
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <TableRow key={headerGroup.id}>
+                {headerGroup.headers.map((header) => {
+                  return (
+                    <TableHead key={header.id}>
+                      {header.isPlaceholder
+                        ? null
+                        : flexRender(
+                            header.column.columnDef.header,
+                            header.getContext()
+                          )}
+                    </TableHead>
+                  );
+                })}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {table.getRowModel().rows?.length ? (
+              table.getRowModel().rows.map((row) => (
+                <TableRow
+                  key={row.id}
+                  data-state={row.getIsSelected() && "selected"}
+                >
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell key={cell.id}>
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext()
+                      )}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell
+                  colSpan={columns.length}
+                  className="h-24 text-center"
+                >
+                  No results.
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+      <div className="flex items-center justify-between py-4">
+        <DataTablePagination table={table} />
+      </div>
+    </>
+  );
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,8 +1,22 @@
-export default function PrivatePage() {
+import { getAllDraftTournaments, getAllDraftEvents } from "@/lib/api";
+import { tournamentColumns } from "./tournaments-columns";
+import { TournamentsDataTable } from "./tournaments-data-table";
+import { eventsColumns } from "./events-columns";
+import { EventsDataTable } from "./events-data-table";
+
+export default async function PrivatePage() {
+  const tournaments = await getAllDraftTournaments();
+  const events = await getAllDraftEvents();
   return (
     <>
       <div className="flex items-center">
         <h1 className="text-lg font-semibold md:text-2xl">Dashboard</h1>
+      </div>
+      <div className="md:container mx-auto">
+        <h2 className="text-lg font-semibold md:text-2xl">Eventos</h2>
+        <EventsDataTable columns={eventsColumns} data={events} />
+        <h2 className="text-lg font-semibold md:text-2xl">Torneos</h2>
+        <TournamentsDataTable columns={tournamentColumns} data={tournaments} />
       </div>
     </>
   );

--- a/src/app/dashboard/torneos/columns.tsx
+++ b/src/app/dashboard/torneos/columns.tsx
@@ -27,6 +27,7 @@ export type Torneo = {
   time: string;
   casino: Casino;
   event: Event;
+  draft: boolean;
 };
 
 export const columns: ColumnDef<Torneo>[] = [
@@ -73,6 +74,16 @@ export const columns: ColumnDef<Torneo>[] = [
     header: ({ column }) => (
       <DataTableColumnHeader column={column} title="Hora" />
     ),
+  },
+  {
+    accessorKey: "draft",
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title="Draft" />
+    ),
+    cell: ({ row }) => {
+      const torneo = row.original;
+      return torneo.draft ? "Sí" : "";
+    },
   },
   {
     id: "actions",

--- a/src/app/dashboard/torneos/edit/form-torneo.tsx
+++ b/src/app/dashboard/torneos/edit/form-torneo.tsx
@@ -28,6 +28,7 @@ import { useState } from "react";
 import { RefreshCcw, Search } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { Textarea } from "@/components/ui/textarea";
+import { Switch } from "@/components/ui/switch";
 
 export default function FormTorneo({
   torneo,
@@ -50,6 +51,7 @@ export default function FormTorneo({
   const [fee, setFee] = useState(torneo ? torneo.fee : "");
   const [points, setPoints] = useState(torneo ? torneo.points : "");
   const [leveltime, setLeveltime] = useState(torneo ? torneo.leveltime : "");
+  const [draft, setDraft] = useState(torneo ? torneo.draft : null);
   const [punctuality, setPunctuality] = useState(
     torneo ? torneo.punctuality : ""
   );
@@ -97,6 +99,7 @@ export default function FormTorneo({
           punctuality,
           bounty,
           content,
+          draft,
         })
         .then(() => {
           setLoading(false);
@@ -121,6 +124,7 @@ export default function FormTorneo({
           punctuality,
           bounty,
           content,
+          draft,
         })
         .eq("id", torneo.id)
         .then(() => {
@@ -322,6 +326,10 @@ export default function FormTorneo({
             defaultValue={content}
             onChange={(e) => setContent(e.target.value)}
           />
+        </div>
+        <div className="flex items-center space-x-4">
+          <Label htmlFor="draft">Draft</Label>
+          <Switch checked={draft} onCheckedChange={() => setDraft(!draft)} />
         </div>
 
         <div className="flex justify-end gap-4">

--- a/src/app/dashboard/tournaments-columns.tsx
+++ b/src/app/dashboard/tournaments-columns.tsx
@@ -3,7 +3,7 @@
 
 import { DataTableColumnHeader } from "@/components/datatables/column-header";
 import { ColumnDef } from "@tanstack/react-table";
-import { Pencil, SquareArrowOutUpRight } from "lucide-react";
+import { Copy, Pencil, SquareArrowOutUpRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
 
@@ -12,25 +12,25 @@ export type Casino = {
   name: string;
 };
 
-export type Tour = {
+export type Event = {
   id: number;
   name: string;
 };
 
-export type Event = {
+export type Torneo = {
   id: number;
   name: string;
   slug: string;
   casinoId: number;
-  tourId: number;
-  from: string;
-  to: string;
+  eventId: number;
+  date: string;
+  time: string;
   casino: Casino;
-  tour: Tour;
+  event: Event;
   draft: boolean;
 };
 
-export const columns: ColumnDef<Event>[] = [
+export const tournamentColumns: ColumnDef<Torneo>[] = [
   {
     accessorKey: "id",
     header: ({ column }) => (
@@ -49,59 +49,64 @@ export const columns: ColumnDef<Event>[] = [
       <DataTableColumnHeader column={column} title="Casino" />
     ),
     cell: ({ row }) => {
-      const evento = row.original;
-      return evento.casino.name;
+      const torneo = row.original;
+      return torneo.casino.name;
     },
   },
   {
-    accessorKey: "tour",
+    accessorKey: "event",
     header: ({ column }) => (
-      <DataTableColumnHeader column={column} title="Circuito" />
+      <DataTableColumnHeader column={column} title="Evento" />
     ),
     cell: ({ row }) => {
-      const evento = row.original;
-      return evento.tour.name;
+      const torneo = row.original;
+      return torneo.event ? torneo.event.name : "";
     },
   },
   {
-    accessorKey: "from",
+    accessorKey: "date",
     header: ({ column }) => (
-      <DataTableColumnHeader column={column} title="Desde" />
+      <DataTableColumnHeader column={column} title="Fecha" />
     ),
   },
   {
-    accessorKey: "to",
+    accessorKey: "time",
     header: ({ column }) => (
-      <DataTableColumnHeader column={column} title="Hasta" />
+      <DataTableColumnHeader column={column} title="Hora" />
     ),
   },
   {
-    accessorKey: "dradft",
+    accessorKey: "draft",
     header: ({ column }) => (
       <DataTableColumnHeader column={column} title="Draft" />
     ),
     cell: ({ row }) => {
-      const evento = row.original;
-      return evento.draft ? "Sí" : "";
+      const torneo = row.original;
+      return torneo.draft ? "Sí" : "";
     },
   },
   {
     id: "actions",
     cell: ({ row }) => {
-      const evento = row.original;
+      const torneo = row.original;
 
       return (
         <div className="flex items-center justify-end gap-2">
           <Button variant="outline" className="h-6 w-6 p-0">
             <a
-              href={"https://torneospokerlive.com/eventos/" + evento.slug}
+              href={"https://torneospokerlive.com/torneos/" + torneo.slug}
               target="_blank"
             >
               <SquareArrowOutUpRight className="h-4 w-4" />
             </a>
           </Button>
           <Button variant="outline" className="h-6 w-6 p-0">
-            <Link href={"/dashboard/eventos/edit/" + evento.id}>
+            <Link href={"/dashboard/torneos/clone/" + torneo.id}>
+              <Copy className="h-4 w-4" />
+            </Link>
+          </Button>
+          <Button variant="outline" className="h-6 w-6 p-0">
+            <Link href={"/dashboard/torneos/edit/" + torneo.id}>
               <Pencil className="h-4 w-4" />
             </Link>
           </Button>

--- a/src/app/dashboard/tournaments-data-table.tsx
+++ b/src/app/dashboard/tournaments-data-table.tsx
@@ -1,0 +1,131 @@
+"use client";
+import * as React from "react";
+
+import {
+  ColumnDef,
+  SortingState,
+  ColumnFiltersState,
+  flexRender,
+  getCoreRowModel,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { DataTablePagination } from "@/components/datatables/pagination";
+import { Input } from "@/components/ui/input";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+interface DataTableProps<TData, TValue> {
+  columns: ColumnDef<TData, TValue>[];
+  data: TData[];
+}
+
+export function TournamentsDataTable<TData, TValue>({
+  columns,
+  data,
+}: DataTableProps<TData, TValue>) {
+  const [sorting, setSorting] = React.useState<SortingState>([]);
+
+  const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>(
+    []
+  );
+
+  const table = useReactTable({
+    data,
+    columns,
+    getPaginationRowModel: getPaginationRowModel(),
+    getCoreRowModel: getCoreRowModel(),
+    onSortingChange: setSorting,
+    getSortedRowModel: getSortedRowModel(),
+    onColumnFiltersChange: setColumnFilters,
+    getFilteredRowModel: getFilteredRowModel(),
+
+    state: {
+      sorting,
+      columnFilters,
+    },
+  });
+
+  return (
+    <>
+      <div className="flex items-center justify-between py-4 gap-2">
+        <Input
+          placeholder="Buscar Torneo..."
+          value={(table.getColumn("name")?.getFilterValue() as string) ?? ""}
+          onChange={(event) => {
+            table.getColumn("name")?.setFilterValue(event.target.value);
+          }}
+          className="max-w-sm"
+        />
+
+        <Link href="/admin/torneos/edit">
+          <Button>Nuevo Torneo</Button>
+        </Link>
+      </div>
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <TableRow key={headerGroup.id}>
+                {headerGroup.headers.map((header) => {
+                  return (
+                    <TableHead key={header.id}>
+                      {header.isPlaceholder
+                        ? null
+                        : flexRender(
+                            header.column.columnDef.header,
+                            header.getContext()
+                          )}
+                    </TableHead>
+                  );
+                })}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {table.getRowModel().rows?.length ? (
+              table.getRowModel().rows.map((row) => (
+                <TableRow
+                  key={row.id}
+                  data-state={row.getIsSelected() && "selected"}
+                >
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell key={cell.id}>
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext()
+                      )}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell
+                  colSpan={columns.length}
+                  className="h-24 text-center"
+                >
+                  No results.
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+      <div className="flex items-center justify-between py-4">
+        <DataTablePagination table={table} />
+      </div>
+    </>
+  );
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -11,6 +11,18 @@ export async function getAllTournaments() {
   return data;
 }
 
+export async function getAllDraftTournaments() {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from("Tournament")
+    .select("*, casinoId, casino:Casino(*), event:Event(*, tour:Tour(*))")
+    .eq("draft", true)
+    .order("date", { ascending: false })
+    .order("time", { ascending: true });
+  if (error) throw error;
+  return data;
+}
+
 export async function getTournamentById(id: number) {
   const supabase = createClient();
   const { data, error } = await supabase
@@ -75,6 +87,17 @@ export async function getAllEvents() {
   const { data, error } = await supabase
     .from("Event")
     .select("*, tour:Tour(*), casino:Casino(*)")
+    .order("from", { ascending: false });
+  if (error) throw error;
+  return data;
+}
+
+export async function getAllDraftEvents() {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from("Event")
+    .select("*, tour:Tour(*), casino:Casino(*)")
+    .eq("draft", true)
     .order("from", { ascending: false });
   if (error) throw error;
   return data;


### PR DESCRIPTION
This pull request adds the functionality to create and manage draft tournaments and events. It includes changes to the columns and form components for both tournaments and events, as well as updates to the API to support fetching and saving draft data.